### PR TITLE
Normalizing signature before running verification

### DIFF
--- a/JOSESwift/Sources/Secp256k1Verifier.swift
+++ b/JOSESwift/Sources/Secp256k1Verifier.swift
@@ -21,7 +21,7 @@ internal struct Secp256k1Verifier: VerifierProtocol {
         
         var signatureIn = secp256k1_ecdsa_signature()
         var signatureOut = secp256k1_ecdsa_signature()
-        secp256k1_ecdsa_signature_parse_compact(secp256k1.Context.raw, &signatureIn, signature)
+        secp256k1_ecdsa_signature_parse_compact(secp256k1.Context.raw, &signatureIn, signature.bytes)
         secp256k1_ecdsa_signature_normalize(secp256k1.Context.raw, &signatureOut, &signatureIn)
         
         guard let normalizedSignature = try? secp256k1.Signing.ECDSASignature(rawRepresentation: signatureOut.dataValue) else {

--- a/JOSESwift/Sources/Secp256k1Verifier.swift
+++ b/JOSESwift/Sources/Secp256k1Verifier.swift
@@ -18,9 +18,17 @@ internal struct Secp256k1Verifier: VerifierProtocol {
 
     func verify(_ verifyingInput: Data, against signature: Data) throws -> Bool {
         let secp256k1PublicKey = try secp256k1.Signing.PublicKey(rawRepresentation: self.publicKey, format: .uncompressed)
-        let ecdsaSignature = try secp256k1.Signing.ECDSASignature(compactRepresentation: signature)
-        return secp256k1PublicKey.ecdsa.isValidSignature(ecdsaSignature, for: verifyingInput)
+        
+        var signatureIn = secp256k1_ecdsa_signature()
+        var signatureOut = secp256k1_ecdsa_signature()
+        secp256k1_ecdsa_signature_parse_compact(secp256k1.Context.raw, &signatureIn, signature)
+        secp256k1_ecdsa_signature_normalize(secp256k1.Context.raw, &signatureOut, &signatureIn)
+        
+        guard let normalizedSignature = try? secp256k1.Signing.ECDSASignature(rawRepresentation: signatureOut.dataValue) else {
+            throw JOSESwiftError.signatureInvalid
+        }
 
+        return secp256k1PublicKey.ecdsa.isValidSignature(normalizedSignature, for: verifyingInput)
     }
 }
 


### PR DESCRIPTION
Normalizing signature before running verification